### PR TITLE
Feature/log argument formatting

### DIFF
--- a/src/dts/logger.d.ts
+++ b/src/dts/logger.d.ts
@@ -17,11 +17,11 @@ export declare class ComponentLogger implements ZLUX.ComponentLogger {
     FINEST: number;
     constructor(parentLogger: Logger, componentName: string);
     makeSublogger(componentNameSuffix: string): ComponentLogger;
-    log(minimumLevel: number, message: string): void;
-    severe(message: string): void;
-    info(message: string): void;
-    warn(message: string): void;
-    debug(message: string): void;
+    log(minimumLevel: number, ...loggableItems: any[]): void;
+    severe(...loggableItems: any[]): void;
+    info(...loggableItems: any[]): void;
+    warn(...loggableItems: any[]): void;
+    debug(...loggableItems: any[]): void;
 }
 export declare class Logger implements ZLUX.Logger {
     private destinations;
@@ -36,11 +36,11 @@ export declare class Logger implements ZLUX.Logger {
     static FINER: number;
     static FINEST: number;
     constructor();
-    addDestination(destinationCallback: (componentName: string, minimumLevel: LogLevel, message: string) => void): void;
+    addDestination(destinationCallback: (componentName: string, minimumLevel: LogLevel, ...loggableItems: any[]) => void): void;
     private shouldLogInternal;
     private consoleLogInternal;
     makeDefaultDestination(prependDate?: boolean, prependName?: boolean, prependLevel?: boolean): (x: string, y: LogLevel, z: string) => void;
-    log(componentName: string, minimumLevel: LogLevel, message: string): void;
+    log(componentName: string, minimumLevel: LogLevel, ...loggableItems: any[]): void;
     setLogLevelForComponentPattern(componentNamePattern: string, level: LogLevel): void;
     setLogLevelForComponentName(componentName: string, level: LogLevel | number): void;
     getComponentLevel(componentName: string): LogLevel;

--- a/src/logging/package.json
+++ b/src/logging/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "tsc",
     "start": "tsc --watch",
-    "simpleTest": "node simpleTest.js"
+    "simpleTest": "node ../../test/logging/simpleTest.js"
   },
   "author": "Sean Grady",
   "devDependencies": {

--- a/src/logging/package.json
+++ b/src/logging/package.json
@@ -5,7 +5,8 @@
   "license": "private",
   "scripts": {
     "build": "tsc",
-    "start": "tsc --watch"
+    "start": "tsc --watch",
+    "simpleTest": "node simpleTest.js"
   },
   "author": "Sean Grady",
   "devDependencies": {

--- a/src/logging/simpleTest.js
+++ b/src/logging/simpleTest.js
@@ -1,0 +1,52 @@
+const logModule = require('./logger.js');
+
+function testDuplicate(logger) {
+  logger.makeComponentLogger('foo');
+  logger.makeComponentLogger('foo');
+  /* should print
+
+     [2018-11-29 17:54:43.395 WARNING] - Logger created with identical component name to pre-existing logger. Messages overlap may occur.
+  */
+}
+
+function testInfo(logger) {
+  let log = logger.makeComponentLogger('testInfo');
+  try {
+    log.info('FYI this worked');
+  } catch (e) {
+    console.log('testInfo failed, e='+e);
+  }
+  /* should print
+
+     [2018-11-29 17:54:43.400 testInfo INFO] - FYI this worked
+   */
+}
+
+function testArguments(logger) {
+  let log = logger.makeComponentLogger('testArguments');
+  let mystring = 'here it is';
+  let myint = 45;
+  let myboolean = true;
+  let myfunction = function(num1, num2) {return num1+num2;};
+  let myobject = {message: 'this should look familiar', mystring: mystring, myint: myint, myfunction: myfunction, myboolean: myboolean};
+  log.info('Look at my string', mystring, ', and my int', myint, ', and my boolean', myboolean, ', and my function', myfunction, ', and finally my object', myobject);
+  /* should print
+
+     [2018-11-29 17:54:43.401 testArguments INFO] - Look at my string here it is , and my int 45 , and my boolean true , and my function function(num1, num2) {return num1+num2;} , and finally my object { message: 'this should look familiar',
+     mystring: 'here it is',
+     myint: 45,
+     myfunction: [Function: myfunction],
+     myboolean: true }
+
+   */
+}
+
+function runTests() {
+  let logger = new logModule.Logger();
+  logger.addDestination(logger.makeDefaultDestination(true,true,true));
+  testDuplicate(logger);
+  testInfo(logger);
+  testArguments(logger);
+}
+
+runTests();

--- a/test/logging/simpleTest.js
+++ b/test/logging/simpleTest.js
@@ -1,4 +1,4 @@
-const logModule = require('./logger.js');
+const logModule = require('../../src/logging/logger.js');
 
 function testDuplicate(logger) {
   logger.makeComponentLogger('foo');


### PR DESCRIPTION
Replaces https://github.com/zowe/zlux-shared/pull/5 due to github breaking.
Changing logger to utilize n number of args, which for the default destination just passes through to console for clean and helpful logging.
This commit changes the arguments for an interface, so this depends upon zowe/zlux-platform#12

Signed-off-by: 1000TurquoisePogs sgrady@rocketsoftware.com