### PR TITLE
Bugfix for regex for obfuscate

### DIFF
--- a/src/obfuscator/htmlObfuscator.ts
+++ b/src/obfuscator/htmlObfuscator.ts
@@ -16,7 +16,7 @@ export class HtmlObfuscator {
 
   public findAndReplaceHTMLEntities(str: string): string {
     let regexHTMLEnd   = new RegExp('<\/[A-Za-z0-9]+\\s?>');
-    let regexHTMLStart = new RegExp('<[A-Za-z0-9]+(\\s+\\S*)?>|<[A-Za-z0-9]+(\\s?)>');
+    let regexHTMLStart = new RegExp('<[A-Za-z0-9]+(\\s+\\S+.*)?>|<[A-Za-z0-9]+\\s?\/?>');
 
     var newString = str;
 


### PR DESCRIPTION
Regex wasn't catching <foo/> or <foo prop1="foo" prop2="foo'> and similar.