### PR TITLE
update changelog when its PR

### DIFF
--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -45,6 +45,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
   update-changelog:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     outputs:
       was_updated: ${{ steps.check-change.outputs.change_detected }}
@@ -120,6 +121,7 @@ jobs:
           fi
 
   check_changelog:
+    if: github.event_name == 'pull_request'
     needs: update-changelog
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Small update in changelog action, it will check and update changelog when its a PR, Currently some builds show that they are failing because of the changelog, the changelog logic shouldn't run unless if its a pull request.