### PR TITLE
Set specific versions

### DIFF
--- a/src/logging/package-lock.json
+++ b/src/logging/package-lock.json
@@ -9,14 +9,14 @@
       "version": "0.0.0-zlux.version.replacement",
       "license": "private",
       "devDependencies": {
-        "@types/core-js": "~2.5.5",
-        "@types/node": "~14.14.22",
-        "core-js": "~3.19.0",
-        "mocha": "~10.3.0",
-        "nyc": "~15.1.0",
-        "rxjs": "~7.4.0",
-        "sinon": "~17.0.1",
-        "typescript": "~4.2.0"
+        "@types/core-js": "2.5.5",
+        "@types/node": "14.14.22",
+        "core-js": "3.19.0",
+        "mocha": "10.3.0",
+        "nyc": "15.1.0",
+        "rxjs": "7.4.0",
+        "sinon": "17.0.1",
+        "typescript": "4.2.4"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/src/logging/package.json
+++ b/src/logging/package.json
@@ -11,13 +11,13 @@
   },
   "author": "Sean Grady",
   "devDependencies": {
-    "@types/core-js": "~2.5.5",
-    "@types/node": "~14.14.22",
-    "core-js": "~3.19.0",
-    "mocha": "~10.3.0",
-    "rxjs": "~7.4.0",
-    "sinon": "~17.0.1",
-    "typescript": "~4.2.0",
-    "nyc": "~15.1.0"
+    "@types/core-js": "2.5.5",
+    "@types/node": "14.14.22",
+    "core-js": "3.19.0",
+    "mocha": "10.3.0",
+    "rxjs": "7.4.0",
+    "sinon": "17.0.1",
+    "typescript": "4.2.4",
+    "nyc": "15.1.0"
   }
 }

--- a/src/obfuscator/package-lock.json
+++ b/src/obfuscator/package-lock.json
@@ -9,11 +9,11 @@
       "version": "0.0.0-zlux.version.replacement",
       "license": "private",
       "devDependencies": {
-        "@types/core-js": "~2.5.5",
-        "@types/node": "~14.14.22",
-        "core-js": "~3.19.0",
-        "rxjs": "~7.4.0",
-        "typescript": "~4.2.0"
+        "@types/core-js": "2.5.5",
+        "@types/node": "14.14.22",
+        "core-js": "3.19.0",
+        "rxjs": "7.4.0",
+        "typescript": "4.2.4"
       }
     },
     "node_modules/@types/core-js": {

--- a/src/obfuscator/package.json
+++ b/src/obfuscator/package.json
@@ -8,10 +8,10 @@
   },
   "author": "Jordan Filteau",
   "devDependencies": {
-    "@types/core-js": "~2.5.5",
-    "@types/node": "~14.14.22",
-    "core-js": "~3.19.0",
-    "rxjs": "~7.4.0",
-    "typescript": "~4.2.0"
+    "@types/core-js": "2.5.5",
+    "@types/node": "14.14.22",
+    "core-js": "3.19.0",
+    "rxjs": "7.4.0",
+    "typescript": "4.2.4"
   }
 }


### PR DESCRIPTION
This PR sets all package.json versions to what was found in package-lock.json to set a baseline for specific versions rather than relying on version ranges.